### PR TITLE
eval notes_off logic on every frame tick

### DIFF
--- a/lib/library/_midi.lua
+++ b/lib/library/_midi.lua
@@ -1,5 +1,5 @@
 local midi_out = function ( self, x, y )
-  
+
   self.y = y
   self.x = x
   self.name = 'midi'
@@ -8,16 +8,16 @@ local midi_out = function ( self, x, y )
   local channel = util.clamp( self:listen( self.x + 1, self.y ) or 0, 0, 16 )
   local octave = util.clamp( self:listen( self.x + 2, self.y ) or 4, 0, 8 )
   local vel = util.clamp( self:listen( self.x + 4, self.y ) or 10, 0, 16 )
-  local length = self:listen( self.x + 5, self.y ) or 1 
+  local length = self:listen( self.x + 5, self.y ) or 1
   local note = self:glyph_at(self.x + 3, self.y) or 'C'
   local transposed = self:transpose( note, octave )
   local n, oct, velocity = transposed[1], transposed[4], math.floor(( vel / 16 ) * 127 )
+  self:notes_off(channel)
   if self:neighbor(self.x, self.y, '*') then
-    self:notes_off(channel)
     self.midi_out_device:note_on( n, velocity, channel )
     self:add_note(channel, n, length, false)
   end
-  
+
 end
 
 return midi_out


### PR DESCRIPTION
See original comment on Lines [here](https://llllllll.co/t/orca/22492/183).

My understanding of the note & midi code is that we would want to evaluate whether or not a note should be "turned off" every tick, as opposed to when a midi OP is banged. Without this change, we effectively never send a `note off` message to midi, and the `length` parameter doesn't do anything. 

With this change `length` is respected and the `note off` message is sent to midi after the appropriate number of frames have passed. 